### PR TITLE
Add a skipQueue option

### DIFF
--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -28,6 +28,10 @@ exports.options = {
   cookie_options: {},
   cookie_secret: null,
 
+  // Set `skipQueue` to true to disable the queueing mechanism: requests will
+  // be made in real time, but the rating limit protection will be disabled.
+  skipQueue: false,
+
   urls: {
     appAuth: 'https://api.twitter.com/oauth2/token',
     restBase: 'https://api.twitter.com/1.1'

--- a/lib/rest.js
+++ b/lib/rest.js
@@ -88,6 +88,12 @@ module.exports = function TwitterRest(options) {
       stream: false
     });
 
+    // Force `opts.skipQueue` (local options) if `options.skipQueue` (global
+    // options) is set to `true`. In this case, `opts.skipQueue` is ignored.
+    if (options.skipQueue) {
+      opts.skipQueue = true;
+    }
+
     if (post) {
       if (!params) {
         throw new errors.ArgumentRequiredError('params', 'for POST');


### PR DESCRIPTION
Defaults to false. If set to true, the queueing mechanism will be
disabled: requests will be made in real time, but the rating limit
protection will be disabled.

Closes #4
